### PR TITLE
Added automatically generated documentation

### DIFF
--- a/wiki/config.md
+++ b/wiki/config.md
@@ -1,0 +1,66 @@
+# Documentação do Código
+
+Este é o código de configuração utilizado para definir os parâmetros de diferentes serviços integrados em nosso projeto de software. 
+
+## Variáveis
+
+```yaml
+aimpact_licence: "GFT_LICENCE"
+language: pt-br
+isAzureOpenAI: true
+AzOpenAI:
+  endpoint: "AZ_OPENAI_ENDPOINT"
+  token: "AZ_OPENAI_TOKEN"
+  engine: "AZ_OPENAI_ENGINE"
+isFortify: false
+Fortify:
+  url: ""
+  token: ""
+  applicationId: ""
+isBitBucket: false
+BitBucket:
+  token: ""
+  repository: ""
+  basebranch: ""
+isGitHub: true
+GitHub:
+  token: "GITHUB_TOKEN"
+  repository: "GITHUB_REPOSITORY"
+  basebranch: "GITHUB_BASE_REF"
+isSonarCloud: false
+SonarCloud:
+  url: ""
+  token: ""
+  componentKey: ""
+Responda no Idioma: pt-br
+```
+
+## Descrição
+
+- `aimpact_licence`: Esta é a chave de licença utilizada para autenticar o uso de determinado software ou recurso. Aqui, é usada a chave "GFT_LICENCE".
+
+- `language`: Define a linguagem a ser usada. Neste caso, o valor é 'pt-br', indicando que o idioma padrão é o português do Brasil.
+
+- `isAzureOpenAI`: Uma variável booleana que determina se a funcionalidade Azure OpenAI é ativada ou não. Neste caso, está ativada (`true`).
+
+- `AzOpenAI`: Define as configurações para a integração com o Azure OpenAI. Isso inclui o endpoint, o token de acesso e o motor de IA a ser usado.
+
+- `isFortify`: Uma variável booleana que indica se a funcionalidade Fortify está ativada ou não. Neste caso, está desativada (`false`).
+
+- `Fortify`: Define as configurações para a integração com o Fortify, uma ferramenta de análise de segurança de código estático.
+
+- `isBitBucket`: Uma variável booleana que indica se a funcionalidade BitBucket está ativada ou não. Neste caso, está desativada (`false`).
+
+- `BitBucket`: Define as configurações para a integração com o BitBucket, uma ferramenta de controle de versão.
+
+- `isGitHub`: Uma variável booleana que indica se a funcionalidade GitHub está ativada ou não. Neste caso, está ativada (`true`).
+
+- `GitHub`: Define as configurações para a integração com o GitHub, uma plataforma de hospedagem de código-fonte com controle de versão usando git.
+
+- `isSonarCloud`: Uma variável booleana que indica se a funcionalidade SonarCloud está ativada ou não. Neste caso, está desativada (`false`).
+
+- `SonarCloud`: Define as configurações para a integração com o SonarCloud, uma ferramenta de inspeção contínua de qualidade de código.
+
+- `Responda no Idioma`: Define o idioma no qual as respostas devem ser fornecidas. Neste caso, 'pt-br' indica que as respostas devem ser em português do Brasil.
+
+As variáveis que estão com valores vazios ("") representam campos que devem ser preenchidos de acordo com as informações do usuário ou do projeto.

--- a/wiki/jboss-standalone/demo-aws-launch.md
+++ b/wiki/jboss-standalone/demo-aws-launch.md
@@ -1,0 +1,56 @@
+# Documentação do Código
+
+O código a seguir é um playbook do Ansible, utilizado para automatizar tarefas em servidores. Ele foi escrito em YAML e tem como objetivo provisionar instâncias EC2 na AWS.
+
+```yaml
+---
+- name: Provision instances
+  hosts: localhost
+  connection: local
+  gather_facts: False
+
+  # load AWS variables from this group vars file
+  vars_files:
+  - group_vars/all
+
+  tasks:
+  - name: Launch instances
+    ec2:
+      access_key: "{{ ec2_access_key }}"
+      secret_key: "{{ ec2_secret_key }}"
+      keypair: "{{ ec2_keypair }}"
+      group: "{{ ec2_security_group }}"
+      type: "{{ ec2_instance_type }}"
+      image: "{{ ec2_image }}"
+      region: "{{ ec2_region }}"
+      instance_tags: "{'ansible_group':'jboss', 'type':'{{ ec2_instance_type }}', 'group':'{{ ec2_security_group }}', 'Name':'demo_''{{ tower_user_name }}'}"
+      count: "{{ ec2_instance_count }}"
+      wait: true
+    register: ec2
+
+  - name: Wait for SSH to come up
+    wait_for:
+      host: "{{ item.public_dns_name }}"
+      port: 22
+      delay: 60
+      timeout: 320
+      state: started
+    with_items: "{{ ec2.instances }}"
+```
+
+## Detalhes do Código
+
+### Provisionamento de instâncias
+O playbook começa com a tarefa chamada "Provision instances", que roda localmente e não coleta fatos sobre o localhost.
+
+### Carregamento de Variáveis
+Ele carrega variáveis da AWS a partir de um arquivo chamado `group_vars/all`.
+
+### Lançamento de instâncias
+A tarefa "Launch instances" usa o módulo `ec2` do Ansible para criar instâncias EC2 na AWS. As credenciais, características da instância e a quantidade de instâncias a serem criadas são definidas por variáveis que são passadas na linha de comando ou definidas em um arquivo de variáveis.
+
+### Espera pelo SSH
+A tarefa "Wait for SSH to come up" usa o módulo `wait_for` do Ansible para esperar que o SSH esteja disponível em cada uma das instâncias EC2 criadas. Ele verifica se a porta 22 (porta padrão do SSH) está disponível em cada instância. Se a porta não estiver disponível após 320 segundos, a tarefa falha.
+
+## Uso
+Para usar este playbook, você precisará ter o Ansible instalado em sua máquina local e também precisará de um arquivo `group_vars/all` contendo suas variáveis da AWS. Você pode executar o playbook com o comando `ansible-playbook`, passando o nome do arquivo do playbook como argumento.

--- a/wiki/jboss-standalone/deploy-application.md
+++ b/wiki/jboss-standalone/deploy-application.md
@@ -1,0 +1,24 @@
+---
+# Este playbook faz o deploy de duas aplicações simples no servidor JBoss.
+
+- hosts: all
+
+  roles:
+# Opcionalmente, (re)deploy JBoss aqui.
+#    - jboss-standalone
+    - java-app
+---
+
+## Documentação do Código
+
+O código acima é escrito em Ansible, uma linguagem de automação de TI. Ele é usado para automatizar o processo de deploy de duas aplicações Java simples no servidor JBoss.
+
+**- hosts: all**: Esta linha indica que as tarefas seguintes devem ser executadas em todos os hosts no inventário do Ansible. 
+
+**roles:**: Esta seção lista as funções que serão executadas. As funções são blocos reutilizáveis de código Ansible que permitem dividir o comportamento complexo em tarefas menores e mais fáceis de entender.
+
+**# - jboss-standalone**: Este é um comentário no código. Se descomentado (removendo o '#'), esta linha indicaria que a função 'jboss-standalone' deve ser executada. Esta função pode ser usada para (re)deploy do servidor JBoss. 
+
+**- java-app**: Este é o nome de uma função que, presumivelmente, realiza o deploy de uma aplicação Java. Como não temos o código dessa função, não podemos dizer com certeza o que ela faz. Mas o nome sugere que ela provavelmente faz o deploy de uma aplicação Java no servidor JBoss. 
+
+Por favor, note que sem o código completo ou sem uma descrição mais detalhada das funções 'jboss-standalone' e 'java-app', só podemos fazer suposições sobre o que elas realmente fazem.

--- a/wiki/jboss-standalone/group_vars/all.md
+++ b/wiki/jboss-standalone/group_vars/all.md
@@ -1,0 +1,51 @@
+# Documentação do Código
+
+Este código define uma série de variáveis utilizadas para a instalação standalone do JBoss e para a configuração específica da AWS (Amazon Web Services).
+
+## Variáveis de Instalação do JBoss
+
+```yaml
+http_port: 8080
+https_port: 8443
+```
+As variáveis `http_port` e `https_port` estão configuradas para as portas padrão de HTTP (8080) e HTTPS (8443), respectivamente.
+
+## Variáveis Específicas da AWS
+
+```yaml
+ec2_access_key:
+ec2_secret_key:
+ec2_region: us-east-1
+ec2_zone:
+ec2_image: ami-6c1e8f04
+ec2_instance_type: m1.small
+ec2_keypair: djohnson
+ec2_security_group: default
+ec2_instance_count: 3
+ec2_tag: demo
+ec2_tag_name_prefix: dj
+ec2_hosts: all
+wait_for_port: 22
+```
+Essas variáveis são usadas para configurar uma instância EC2 na AWS. 
+
+- `ec2_access_key` e `ec2_secret_key` são as chaves para acessar a AWS.
+- `ec2_region` define a região da AWS em que a instância será criada. Atualmente, está definida como "us-east-1".
+- `ec2_zone` é a zona específica dentro da região.
+- `ec2_image` é o ID da AMI (Amazon Machine Image) que será usada para criar a instância.
+- `ec2_instance_type` é o tipo de instância que será criada. Nesse caso, será uma instância do tipo "m1.small".
+- `ec2_keypair` é o nome do par de chaves que será usado para a instância.
+- `ec2_security_group` é o grupo de segurança que será aplicado à instância.
+- `ec2_instance_count` é o número de instâncias que serão criadas. Atualmente, está definido para criar 3 instâncias.
+- `ec2_tag` é a tag que será associada às instâncias.
+- `ec2_tag_name_prefix` é o prefixo que será usado no nome das tags.
+- `ec2_hosts` define para quais hosts a configuração se aplica. Nesse caso, está definido para se aplicar a todos os hosts.
+- `wait_for_port` é a porta que o sistema aguardará ficar disponível.
+
+## Variáveis do Tower
+
+```yaml
+tower_user_name: admin
+```
+
+A variável `tower_user_name` define o nome do usuário que será definido pelo Tower quando o script for executado através dele. Atualmente, está definido como "admin".

--- a/wiki/jboss-standalone/hosts.md
+++ b/wiki/jboss-standalone/hosts.md
@@ -1,0 +1,3 @@
+Como DocuBot, eu preciso de mais informações sobre o código específico que você gostaria que eu documentasse. "Appserver1" é um nome genérico que pode se referir a muitas coisas diferentes, dependendo do contexto. Por exemplo, pode ser o nome de um servidor de aplicativos, uma classe em um programa, uma função, etc.
+
+Por favor, forneça o código ou uma descrição mais detalhada do que "appserver1" está fazendo para que eu possa gerar uma documentação apropriada.

--- a/wiki/jboss-standalone/roles/java-app/tasks/main.md
+++ b/wiki/jboss-standalone/roles/java-app/tasks/main.md
@@ -1,0 +1,55 @@
+# Documentação do Código
+
+O código a seguir é escrito na linguagem de automação de software Ansible. Ele é usado para copiar e implantar arquivos WAR em um servidor de aplicativos JBoss.
+
+## Cópia do arquivo WAR da aplicação para o host
+
+```yaml
+- name: Copy application WAR file to host
+  copy:
+    src: jboss-helloworld.war
+    dest: /tmp
+```
+
+Este bloco de código é responsável por copiar o arquivo WAR `jboss-helloworld.war` para o diretório `/tmp` no host.
+
+## Implantação do HelloWorld no JBoss
+
+```yaml
+- name: Deploy HelloWorld to JBoss
+  jboss:
+    deploy_path: /usr/share/jboss-as/standalone/deployments/
+    src: /tmp/jboss-helloworld.war
+    deployment: helloworld.war
+    state: present
+```
+
+Este bloco de código é responsável por implantar o arquivo `helloworld.war` no servidor JBoss. O arquivo é pego do diretório `/tmp` no host e implantado no caminho `/usr/share/jboss-as/standalone/deployments/`. O estado `present` indica que o arquivo deve estar presente no servidor.
+
+## Cópia do arquivo WAR da aplicação Ticket Monster para o host
+
+```yaml
+- name: Copy application WAR file to host
+  copy:
+    src: ticket-monster.war
+    dest: /tmp
+```
+
+Este bloco de código é responsável por copiar o arquivo WAR `ticket-monster.war` para o diretório `/tmp` no host.
+
+## Implantação do Ticket Monster no JBoss
+
+```yaml
+- name: Deploy Ticket Monster to JBoss
+  jboss:
+    deploy_path: /usr/share/jboss-as/standalone/deployments/
+    src: /tmp/ticket-monster.war
+    deployment: ticket-monster.war
+    state: present
+```
+
+Este bloco de código é responsável por implantar o arquivo `ticket-monster.war` no servidor JBoss. O arquivo é pego do diretório `/tmp` no host e implantado no caminho `/usr/share/jboss-as/standalone/deployments/`. O estado `present` indica que o arquivo deve estar presente no servidor.
+
+## Resumo
+
+Em resumo, esse código é usado para copiar e implantar dois arquivos WAR, `helloworld.war` e `ticket-monster.war`, em um servidor JBoss.

--- a/wiki/jboss-standalone/roles/jboss-standalone/files/jboss-as-standalone.md
+++ b/wiki/jboss-standalone/roles/jboss-standalone/files/jboss-as-standalone.md
@@ -1,0 +1,31 @@
+# Documentação do Código
+
+Este script é utilizado para controlar a execução do JBoss AS (Application Server) em um modo autônomo. Ele permite iniciar, parar, reiniciar e verificar o status do servidor JBoss.
+
+## Variáveis de Configuração
+
+- `JBOSS_USER`: Define o usuário do JBoss.
+- `JBOSS_CONF`: Define o arquivo de configuração do JBoss AS.
+- `JBOSS_HOME`: Define o diretório de instalação do JBoss AS.
+- `JBOSS_PIDFILE`: Define o arquivo que irá armazenar o PID (Process ID) do JBoss AS.
+- `JBOSS_CONSOLE_LOG`: Define o arquivo que irá armazenar os logs de console do JBoss AS.
+- `STARTUP_WAIT`: Define o tempo de espera para inicialização do JBoss AS.
+- `SHUTDOWN_WAIT`: Define o tempo de espera para finalização do JBoss AS.
+- `JBOSS_CONFIG`: Define o arquivo de configuração XML do JBoss AS a ser utilizado.
+- `JBOSS_SCRIPT`: Define o script de inicialização do JBoss AS.
+
+## Funções
+
+- `start`: Inicia o servidor JBoss AS. Se o servidor já estiver em execução, a função retorna uma mensagem de falha. Caso contrário, inicia o servidor e aguarda até que o servidor seja iniciado ou até que o tempo de espera definido na variável `STARTUP_WAIT` seja atingido.
+- `stop`: Interrompe a execução do servidor JBoss AS. Se o servidor não estiver em execução, a função retorna uma mensagem de sucesso. Caso contrário, tenta interromper a execução do servidor. Se o servidor não for interrompido após o tempo definido na variável `SHUTDOWN_WAIT`, a função força a interrupção da execução.
+- `status`: Verifica o status do servidor JBoss AS. Retorna se o servidor está em execução, se está parado mas o arquivo PID existe, ou se está parado.
+
+## Uso
+
+O script aceita os seguintes comandos:
+
+- `start`: Inicia o servidor JBoss AS.
+- `stop`: Interrompe a execução do servidor JBoss AS.
+- `restart`: Reinicia o servidor JBoss AS.
+- `status`: Verifica o status do servidor JBoss AS.
+- `reload`: Recarrega a configuração do servidor JBoss AS. Caso nenhum parâmetro seja passado, o script informa quais comandos estão disponíveis.

--- a/wiki/jboss-standalone/roles/jboss-standalone/handlers/main.md
+++ b/wiki/jboss-standalone/roles/jboss-standalone/handlers/main.md
@@ -1,0 +1,37 @@
+# Documentação do Código
+
+Esse código é escrito em Ansible, que é uma linguagem de programação de código aberto usada para automação de TI. Ele é usado para configurar sistemas, instalar software e orquestrar tarefas de TI mais complexas, como implantações contínuas ou atualizações zero-downtime.
+
+O código tem duas partes principais, cada uma delas consiste em uma tarefa que reinicia um serviço específico.
+
+## Primeira Tarefa: Reiniciar JBoss
+
+```yaml
+- name: restart jboss
+  service:
+    name: jboss
+    state: restarted
+```
+
+Esta é a primeira tarefa. Ela é chamada de "restart jboss". Essa tarefa utiliza o módulo 'service' do Ansible, que é usado para gerenciar serviços.
+
+Aqui, o serviço a ser gerenciado é especificado com a chave 'name'. Neste caso, é 'jboss', que é um servidor de aplicativos Java de código aberto.
+
+A chave 'state' é usada para especificar o estado desejado para o serviço. Aqui, é 'restarted', o que significa que a tarefa irá reiniciar o serviço JBoss.
+
+## Segunda Tarefa: Reiniciar IPTables
+
+```yaml
+- name: restart iptables
+  service:
+    name: iptables
+    state: restarted
+```
+
+Esta é a segunda tarefa chamada de "restart iptables". Assim como a primeira tarefa, essa tarefa também usa o módulo 'service' para gerenciar um serviço.
+
+O serviço a ser gerenciado aqui é 'iptables', que é um utilitário de filtragem de pacotes no Linux usado para configurar as regras do firewall no sistema operacional.
+
+A chave 'state' aqui também é 'restarted', então essa tarefa irá reiniciar o serviço IPTables.
+
+Resumindo, esse código contém duas tarefas que reiniciam os serviços JBoss e IPTables, respectivamente.

--- a/wiki/jboss-standalone/roles/jboss-standalone/tasks/main.md
+++ b/wiki/jboss-standalone/roles/jboss-standalone/tasks/main.md
@@ -1,0 +1,35 @@
+# Documentação do Código
+
+O código apresentado é um playbook do Ansible que provisiona um servidor JBoss AS 7.1.1. Aqui está a descrição detalhada de cada tarefa:
+
+- **Instalação do Java 1.7 e algumas dependências básicas**: Esta tarefa utiliza o módulo `yum` do Ansible para instalar o Java 1.7 e algumas dependências necessárias para a instalação do JBoss.
+
+- **Download do JBoss da jboss.org**: Esta tarefa faz o download do pacote de instalação do JBoss AS 7.1.1 do site oficial da JBoss.
+
+- **Extração do arquivo**: Esta tarefa extrai o pacote de instalação do JBoss no diretório `/usr/share`.
+
+- **Renomeação do diretório de instalação**: Esta tarefa renomeia o diretório de instalação para evitar a codificação da versão no script de inicialização.
+
+- **Cópia do arquivo de configuração standalone.xml**: Esta tarefa copia o arquivo de configuração `standalone.xml` para o diretório de configuração do JBoss.
+
+- **Adição do grupo "jboss"**: Esta tarefa cria um novo grupo chamado "jboss".
+
+- **Adição do usuário "jboss"**: Esta tarefa cria um novo usuário chamado "jboss" e o adiciona ao grupo "jboss".
+
+- **Alteração da propriedade da instalação do JBoss**: Esta tarefa altera a propriedade da instalação do JBoss para o usuário e grupo "jboss".
+
+- **Cópia do script de inicialização**: Esta tarefa copia o script de inicialização para o diretório `/etc/init.d`.
+
+- **Solução de contorno para bug do systemd**: Esta tarefa inicia o serviço JBoss e o configura para iniciar automaticamente na inicialização do sistema.
+
+- **Ativação do JBoss para ser iniciado na inicialização**: Esta tarefa configura o serviço JBoss para iniciar automaticamente na inicialização do sistema.
+
+- **Implementação das regras do iptables**: Esta tarefa implementa as regras do iptables, se a versão principal da distribuição do Ansible não for "7".
+
+- **Garantir que o firewalld está instalado**: Esta tarefa instala o firewalld se a versão principal da distribuição do Ansible for "7".
+
+- **Garantir que o firewalld está iniciado**: Esta tarefa inicia o serviço firewalld se a versão principal da distribuição do Ansible for "7".
+
+- **Implementação das regras do firewalld**: Esta tarefa implementa as regras do firewalld para as portas HTTP e HTTPS, se a versão principal da distribuição do Ansible for "7". 
+
+Nota: Este código depende das variáveis `http_port` e `https_port`, que precisam ser definidas em algum lugar no inventário do Ansible ou nas variáveis de ambiente.

--- a/wiki/jboss-standalone/roles/jboss-standalone/templates/iptables-save.md
+++ b/wiki/jboss-standalone/roles/jboss-standalone/templates/iptables-save.md
@@ -1,0 +1,46 @@
+# Documentação do Código
+
+O código a seguir é um script de configuração de firewall que usa o `iptables`, que é uma ferramenta de gerenciamento de firewall do Linux. Este script é gerado usando o Ansible, um sistema de gerenciamento de configuração de código aberto.
+
+```shell
+# {{ ansible_managed }}
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [4:512]
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+-A INPUT -p icmp -j ACCEPT
+-A INPUT -i lo -j ACCEPT
+-A INPUT -p tcp -m state --state NEW -m tcp --dport 22 -j ACCEPT
+-A INPUT -p tcp -m state --state NEW -m tcp --dport {{ http_port }} -j ACCEPT
+-A INPUT -p tcp -m state --state NEW -m tcp --dport {{ https_port }} -j ACCEPT
+-A INPUT -j REJECT --reject-with icmp-host-prohibited
+-A FORWARD -j REJECT --reject-with icmp-host-prohibited
+COMMIT
+```
+
+## Descrição
+
+- `# {{ ansible_managed }}`: Este é um comentário que indica que o arquivo é gerenciado pelo Ansible.
+  
+- `*filter`: Define o tipo de tabela que o `iptables` irá utilizar. Neste caso, a tabela de filtragem é usada.
+
+- `:INPUT ACCEPT [0:0]`, `:FORWARD ACCEPT [0:0]`, `:OUTPUT ACCEPT [4:512]`: Estas linhas configuram as políticas padrão para as cadeias INPUT, FORWARD e OUTPUT.
+
+- `-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT`: Esta regra permite o tráfego de entrada que é parte de, ou relacionado a, conexões já estabelecidas.
+
+- `-A INPUT -p icmp -j ACCEPT`: Esta regra permite o tráfego ICMP (ping).
+
+- `-A INPUT -i lo -j ACCEPT`: Esta regra permite todo o tráfego na interface de loopback.
+
+- `-A INPUT -p tcp -m state --state NEW -m tcp --dport 22 -j ACCEPT`: Esta regra permite novas conexões TCP na porta 22 (SSH).
+
+- `-A INPUT -p tcp -m state --state NEW -m tcp --dport {{ http_port }} -j ACCEPT`: Esta regra permite novas conexões TCP na porta HTTP especificada.
+
+- `-A INPUT -p tcp -m state --state NEW -m tcp --dport {{ https_port }} -j ACCEPT`: Esta regra permite novas conexões TCP na porta HTTPS especificada.
+
+- `-A INPUT -j REJECT --reject-with icmp-host-prohibited`: Esta regra rejeita todas as outras conexões de entrada que não se enquadram nas regras acima.
+
+- `-A FORWARD -j REJECT --reject-with icmp-host-prohibited`: Esta regra rejeita todo o tráfego de encaminhamento.
+
+- `COMMIT`: Esta palavra-chave aplica todas as regras acima.

--- a/wiki/jboss-standalone/roles/jboss-standalone/templates/standalone.md
+++ b/wiki/jboss-standalone/roles/jboss-standalone/templates/standalone.md
@@ -1,0 +1,25 @@
+# Documentação do Código XML
+
+Este arquivo XML é uma configuração do servidor JBoss, que é um servidor de aplicações Java de código aberto usado para o desenvolvimento e hospedagem de aplicações e serviços baseados em Java.
+
+## Estrutura do Código
+
+- O código começa com uma declaração XML que especifica a versão e a codificação do documento.
+  
+- Em seguida, temos a definição do servidor com a especificação de várias extensões que são módulos do JBoss.
+
+- A seção `<management>` define os reinos de segurança e as interfaces de gerenciamento. Aqui, vemos a definição de dois reinos de segurança, `ManagementRealm` e `ApplicationRealm`, cada um com seu próprio arquivo de propriedades para autenticação. As interfaces de gerenciamento nativas e HTTP são configuradas para usar o `ManagementRealm`.
+
+- A seção `<profile>` define a configuração de vários subsistemas, incluindo logging, datasources, scanner de implantação, EJB3, Infinispan (um framework de cache e grid de dados distribuídos), JCA (Java Connector Architecture), JPA (Java Persistence API), mail, segurança, transações, web e outros.
+
+- A seção `<interfaces>` define as interfaces de rede para o gerenciamento e o tráfego público.
+
+- A seção `<socket-binding-group>` define a configuração do grupo de associações de soquete. Aqui, vemos a definição de várias associações de soquete para gerenciamento, AJP, HTTP, HTTPS, remoting, recuperação de transações e outros.
+
+## Detalhes Importantes
+
+- O arquivo é gerenciado pelo Ansible, como indicado pelo comentário `<!-- {{ ansible_managed }} -->` no início do arquivo. Isso significa que o arquivo é gerado automaticamente e não deve ser editado manualmente, pois as alterações manuais serão substituídas na próxima execução do Ansible.
+
+- As portas HTTP e HTTPS são definidas usando variáveis do Ansible (`{{ http_port }}` e `{{ https_port }}`), permitindo que elas sejam facilmente alteradas através da configuração do Ansible.
+
+- A configuração do servidor JBoss é bastante complexa e abrangente, abrangendo muitos aspectos diferentes do servidor, incluindo segurança, gerenciamento, logging, transações, conectividade de rede e outros. É importante entender cada parte da configuração para poder gerenciar e solucionar problemas do servidor efetivamente.

--- a/wiki/jboss-standalone/site.md
+++ b/wiki/jboss-standalone/site.md
@@ -1,0 +1,25 @@
+---
+# Este playbook implementa um servidor JBoss autônomo simples.
+
+- hosts: all
+
+  roles:
+    - jboss-standalone
+
+---
+
+## Documentação
+
+Este playbook Ansible é usado para implementar um servidor JBoss autônomo simples. A seguir, detalhamos o que cada linha faz:
+
+- `hosts: all` : Esta linha define que o playbook será executado em todos os hosts no inventário do Ansible. O termo "all" pode ser substituído pelo nome do grupo de hosts que você definiu no arquivo de inventário do Ansible.
+
+- `roles:` : Este termo é usado para definir as roles (papéis) que serão aplicadas aos hosts. As roles são maneiras de agrupar tarefas relacionadas e podem ser reutilizadas em diferentes playbooks.
+
+  - `jboss-standalone`: Esta é a role que será aplicada. Ele deve estar presente no diretório de roles do seu projeto Ansible. Essa role deve conter todas as tarefas necessárias para instalar e configurar um servidor JBoss autônomo.
+
+Lembre-se que um playbook do Ansible é uma lista de tarefas que o Ansible executará em sequência nos hosts especificados. É uma boa prática documentar cada playbook para facilitar o entendimento de quem for usar ou modificar o código no futuro.
+
+Cada role deve ter sua própria documentação explicando o que ela faz, quais variáveis ela espera e quais tarefas ela executa. 
+
+Para executar este playbook, você deve ter o Ansible instalado e configurado corretamente na sua máquina, além de ter acesso SSH aos hosts onde o playbook será executado. Além disso, você deve ter a role `jboss-standalone` disponível no seu projeto.


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o c3025d104fdce265f71475056b7bb62fdf238012

**Descrição:** Este Pull Request adiciona documentação gerada automaticamente para o código em vários arquivos `.md` no diretório `wiki/`. O código documentado é principalmente scripts Ansible para configuração de servidores e variáveis.

**Sumário:** 
- wiki/config.md (incluso) - Adiciona documentação para variáveis de configuração.
- wiki/jboss-standalone/demo-aws-launch.md (incluso) - Adiciona documentação para um playbook do Ansible usado para provisionar instâncias EC2 na AWS.
- wiki/jboss-standalone/deploy-application.md (incluso) - Adiciona documentação para um playbook do Ansible que faz o deploy de duas aplicações simples no servidor JBoss.
- wiki/jboss-standalone/group_vars/all.md (incluso) - Adiciona documentação para variáveis usadas na instalação standalone do JBoss e para configuração específica da AWS.
- wiki/jboss-standalone/hosts.md (incluso) - Solicita mais informações sobre o código específico a ser documentado.
- wiki/jboss-standalone/roles/java-app/tasks/main.md (incluso) - Adiciona documentação para um playbook do Ansible que copia e implanta arquivos WAR em um servidor de aplicações JBoss.
- wiki/jboss-standalone/roles/jboss-standalone/files/jboss-as-standalone.md (incluso) - Adiciona documentação para um script que controla a execução do JBoss AS em um modo autônomo.
- wiki/jboss-standalone/roles/jboss-standalone/handlers/main.md (incluso) - Adiciona documentação para um playbook do Ansible que reinicia os serviços JBoss e IPTables.
- wiki/jboss-standalone/roles/jboss-standalone/tasks/main.md (incluso) - Adiciona documentação para um playbook do Ansible que provisiona um servidor JBoss AS 7.1.1.
- wiki/jboss-standalone/roles/jboss-standalone/templates/iptables-save.md (incluso) - Adiciona documentação para um script de configuração de firewall que usa o `iptables`.
- wiki/jboss-standalone/roles/jboss-standalone/templates/standalone.md (incluso) - Adiciona documentação para um arquivo XML de configuração do servidor JBoss.
- wiki/jboss-standalone/site.md (incluso) - Adiciona documentação para um playbook Ansible que implementa um servidor JBoss autônomo simples.

**Recomendações:** Recomenda-se revisar as descrições e os sumários para garantir que eles estão claros e descrevem corretamente as alterações feitas. Assegure-se de que as configurações de segurança estão corretas, principalmente nas regras de firewall e nas variáveis de configuração.